### PR TITLE
Linear search from low p to high p

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-percentile",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Utility to compute speed percentile from sparse histogram hash.",
   "license": "ISC",
   "main": "percentile.js",

--- a/percentile.js
+++ b/percentile.js
@@ -20,7 +20,7 @@ module.exports = function(histogram, ps, type) {
     if (!Array.isArray(ps)) return +speeds[0];
 
     var percentileSpeeds = [];
-    for (var i in ps) {
+    for (var i = 0; i < ps.length; i++) {
       percentileSpeeds.push(+speeds[0]);
     }
     return percentileSpeeds.length > 1 ? percentileSpeeds : percentileSpeeds[0];
@@ -36,15 +36,8 @@ module.exports = function(histogram, ps, type) {
     break;
 
   default:
-      //R5 with linear estimation of both upper and lower extremes
+    //R5 with linear estimation of both upper and lower extremes
     cdf = getCDF(histogram, -0.5);
-
-      // linearly project a point beyond 1 for interpolating upper tail
-    speeds = Object.keys(cdf);
-    i = speeds.length - 1;
-    var j = speeds.length - 2;
-    var newspeed = 2 * speeds[i] - speeds[j];
-    cdf[newspeed] = 2 * cdf[speeds[i]] - cdf[speeds[j]];
   }
 
   // interpolate speeds
@@ -64,16 +57,33 @@ module.exports.piecewiseLinearInterpolation = function(cdf, ps) {
   // ensure ps is an array
   if (!Array.isArray(ps)) ps = [ps];
 
+  // count number of percentiels above 50
+  var aboveCount = ps.filter(function(x) { return x >= 0.5; }).length;
+  var belowCount = ps.length - aboveCount;
+  if (aboveCount >= belowCount) return module.exports.searchFromHigh(cdf, ps);
+  else return module.exports.searchFromLow(cdf, ps)
+                            .sort(function(a, b) { return b - a; });
+};
+
+
+module.exports.searchFromHigh = function(cdf, ps) {
+
   // sort percentiles in descending order
   ps.sort(function(a, b) { return b - a; });
 
-
-  var percentileSpeeds = [];
+  // linearly project a point beyond 1 for interpolating upper tail
   var speeds = Object.keys(cdf);
   var i = speeds.length - 1;
+  var j = speeds.length - 2;
+  var newspeed = 2 * speeds[i] - speeds[j];
+  cdf[newspeed] = 2 * cdf[speeds[i]] - cdf[speeds[j]];
+
+  var percentileSpeeds = [];
+  speeds = Object.keys(cdf);
+  i = speeds.length - 1;
 
   // loop through desired percentiles
-  for (var j = 0; j < ps.length; j++) {
+  for (j = 0; j < ps.length; j++) {
     var p = ps[j];
 
     // linear search from high to low for interval to interpolate
@@ -92,3 +102,38 @@ module.exports.piecewiseLinearInterpolation = function(cdf, ps) {
   return percentileSpeeds;
 };
 
+module.exports.searchFromLow = function(cdf, ps) {
+
+  // sort percentiles in descending order
+  ps.sort(function(a, b) { return a - b; });
+
+  // linearly project a point beyond 0 for interpolating lower tail
+  var speeds = Object.keys(cdf);
+  var i = 0;
+  var j = 1;
+  var newspeed = 2 * speeds[i] - speeds[j];
+  cdf[newspeed] = 2 * cdf[speeds[i]] - cdf[speeds[j]];
+
+  var percentileSpeeds = [];
+  speeds = Object.keys(cdf);
+  i = 1;
+
+  // loop through desired percentiles
+  for (j = 0; j < ps.length; j++) {
+    var p = ps[j];
+
+    // linear search from high to low for interval to interpolate
+    while (i < speeds.length && cdf[speeds[i]] <= p) i++;
+
+    // interpolate speed
+    var l = +speeds[i - 1];
+    var r = +speeds[i];
+    if (p >= cdf[speeds[i]]) {  // upper extreme
+      var tmp = r; r = l; l = tmp;
+    }
+
+    percentileSpeeds.push(l + (r - l) * (p - cdf[l]) / (cdf[r] - cdf[l]));
+  }
+
+  return percentileSpeeds;
+};

--- a/test/test.percentile.js
+++ b/test/test.percentile.js
@@ -55,8 +55,28 @@ test('R5 cdf', function(t) {
 });
 
 
+test('searchFromHigh vs. searchFromLow', function(t) {
+  var cdf = getCDF(histogram, -0.5);
+
+  var ps = [0.95];
+  t.deepEqual(percentile.searchFromHigh(cdf, ps), percentile.searchFromLow(cdf, ps));
+
+  ps = [0.05];
+  t.deepEqual(percentile.searchFromHigh(cdf, ps), percentile.searchFromLow(cdf, ps));
+
+  ps = [0.4, 0.3, 0.5];
+  var hiSpeeds = percentile.searchFromHigh(cdf, ps);
+  var loSpeeds = percentile.searchFromLow(cdf, ps)
+                           .sort(function(a, b) { return b - a; });
+
+  t.deepEqual(hiSpeeds, loSpeeds);
+
+  t.end();
+});
+
+
 var ps = [0.5, 0.7];  // test Array format
-var p = 0.95;          // test Number format
+var p = 0.95;         // test Number format
 
 test('R4 percentile', function(t) {
   // speeds always in descending order
@@ -66,7 +86,6 @@ test('R4 percentile', function(t) {
   t.equal(speeds[1].toFixed(4), (40 + 10 * 1 / 5).toFixed(4));
 
   var speed = percentile(histogram, p, 'R4');
-  t.type(speed, 'number');
   t.equal(speed.toFixed(4), (50 + 10 * 2.3 / 3).toFixed(4));
 
   t.end();


### PR DESCRIPTION
This PR adds linear search for percentile speed from low to high. If majority of percentiles in the p array is above 0.5, linear search from 1 down; otherwise linearly search from 0 up.

cc @morganherlocker 